### PR TITLE
add onHighlightChange prop

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ type Props = {
   disabled?: boolean,
   target: HTMLElement,
   onSelectionChange(elements: Array<any>): void,
+  onHighlightChange(elements: Array<any>): void,
   elements: Array<HTMLElement>,
   // eslint-disable-next-line react/no-unused-prop-types
   offset?: {
@@ -64,6 +65,7 @@ export default class Selection extends React.PureComponent<Props, State> { // es
   props: Props;
   state: State;
   selectedChildren: Array<number>;
+  highlightedChildren: Array<number>;
 
   constructor(props: Props) {
     super(props);
@@ -77,6 +79,7 @@ export default class Selection extends React.PureComponent<Props, State> { // es
     };
 
     this.selectedChildren = [];
+    this.highlightedChildren = [];
   }
 
   componentDidMount() {
@@ -194,6 +197,10 @@ export default class Selection extends React.PureComponent<Props, State> { // es
     });
 
     this.props.onSelectionChange(this.selectedChildren);
+    if (this.props.onHighlightChange) {
+      this.highlightedChildren = [];
+      this.props.onHighlightChange(this.highlightedChildren);
+    }
     this.selectedChildren = [];
   };
 
@@ -269,7 +276,8 @@ export default class Selection extends React.PureComponent<Props, State> { // es
 
   /**
    * Updates the selected items based on the
-   * collisions with selectionBox
+   * collisions with selectionBox,
+   * also updates the highlighted items if they have changed
    * @private
    */
   updateCollidingChildren = (selectionBox: Box) => {
@@ -290,6 +298,16 @@ export default class Selection extends React.PureComponent<Props, State> { // es
           }
         }
       });
+    }
+    if (this.props.onHighlightChange && JSON.stringify(this.highlightedChildren) !== JSON.stringify(this.selectedChildren)) {
+      this.highlightedChildren = [...this.selectedChildren];
+      if (window.requestAnimationFrame) {
+        window.requestAnimationFrame(() => {
+          this.props.onHighlightChange(this.highlightedChildren);
+        });
+      } else {
+        this.props.onHighlightChange(this.highlightedChildren);
+      }
     }
   };
 
@@ -343,6 +361,7 @@ Selection.propTypes = {
   target: PropTypes.object,
   disabled: PropTypes.bool,
   onSelectionChange: PropTypes.func.isRequired,
+  onHighlightChange: PropTypes.func,
   elements: PropTypes.array.isRequired,
   // eslint-disable-next-line react/no-unused-prop-types
   offset: PropTypes.object,


### PR DESCRIPTION
Hello,

Thank you for your work with react-ds, it's very pleasant to work with.
At Zenchef, we wanted to highlight the selected items while dragging the mouse, and this was a limitation with react-ds API.
Some other libraries provide this, but we they each had their drawbacks, so implementing this functionality in react-ds was our preferred choice.

Would you consider adding this to your package ?

If so, do you need some things to be changed before merging ?

Thank you

# What's in this PR
- Add an onHighlightChange function prop
- Keep an internal array of the currently highlighted items
- Each time the mouse is dragged, we check if the highlighted items have changed, if so we call onHighlightChange (in a requestAnimationFrame if present) with the highlighted items
- When the mouse is released, we call onHighlightChange with an empty array