### PR TITLE
Return endPoint along with selected indices

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The should exist before rendering the `Selection` component.
 
 #### `onSelectionChange`
 
-Function that will be executed when the selection changes. An array of element indexes will be passed (with the same indexes as the `elements` prop).
+Function that will be executed when the selection changes. An array of element indexes will be passed (with the same indexes as the `elements` prop) as the first argument. The second argument will contain the dragging `endPoint` object with `x` and `y` values.
 
 This is where you want to update your state, to highlight them as selected for example.
 

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ export type Box = {
 type Props = {
   disabled?: boolean,
   target: HTMLElement,
-  onSelectionChange?: (elements: Array<any>) => void,
+  onSelectionChange?: (elements: Array<any>, point: Point) => void,
   onHighlightChange?: (elements: Array<any>) => void,
   elements: Array<HTMLElement>,
   // eslint-disable-next-line react/no-unused-prop-types
@@ -189,6 +189,8 @@ export default class Selection extends React.PureComponent<Props, State> { // es
     window.document.removeEventListener('mouseup', this.onMouseUp);
     window.document.removeEventListener('touchend', this.onMouseUp);
 
+    const endPoint = {...this.state.endPoint};
+
     this.setState({
       mouseDown: false,
       startPoint: null,
@@ -197,7 +199,7 @@ export default class Selection extends React.PureComponent<Props, State> { // es
     });
 
     if (this.props.onSelectionChange) {
-      this.props.onSelectionChange(this.selectedChildren);
+      this.props.onSelectionChange(this.selectedChildren, endPoint);
     }
 
     if (this.props.onHighlightChange) {


### PR DESCRIPTION
Having the `endPoint` as second argument of `onSelectionChange` could help with some UX stuff, like popping up some actions panel for highlighted elements in that point.