### PR TITLE
Use getDerivedStateFromProps instead of componentWillReceiveProps to remove warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-- '6'
+- stable
 script:
 - npm test
 after_success:

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "homepage": "https://github.com/aurbano/react-ds#readme",
   "peerDependencies": {
-    "react": "^^15.0.0-rc || ^15.0 || ^16.0"
+    "react": "^16.3"
   },
   "devDependencies": {
     "babel-cli": "6.26.0",

--- a/src/index.js
+++ b/src/index.js
@@ -84,15 +84,15 @@ export default class Selection extends React.PureComponent<Props, State> { // es
     this.highlightedChildren = [];
   }
 
+  static getDerivedStateFromProps(nextProps: Props) {
+    return {
+      offset: getOffset(nextProps),
+    };
+  }
+
   componentDidMount() {
     this.reset();
     this.bind();
-  }
-
-  componentWillReceiveProps(nextProps: Props) {
-    this.setState({
-      offset: getOffset(nextProps),
-    });
   }
 
   componentDidUpdate() {


### PR DESCRIPTION
Using the Selection component in recent versions of React will show this warning:

![image](https://user-images.githubusercontent.com/43239788/78994946-30c83180-7b39-11ea-8cb9-e2985e60f6ac.png)

This change removes the warning, but means that the library would now require React >= 16.3.
Alternatively, [react-lifecycles-compat](https://github.com/reactjs/react-lifecycles-compat) could be used to maintain compatibility with React 15, but this would mean adding a dependency.