### PR TITLE
Remove inline-elements transform

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -31,8 +31,7 @@
     "production": {
       "plugins": [
         "transform-react-remove-prop-types",
-        "transform-react-constant-elements",
-        "transform-react-inline-elements"
+        "transform-react-constant-elements"
       ]
     },
     "test": {


### PR DESCRIPTION
This transform should never be used, and is actively harmful for performance since it causes deopts within React.

In addition to being harmful in React, it also breaks Preact compatibility (here is [a "patched" codesandbox](https://codesandbox.io/s/react-ds-preact-forked-ev8rm?file=/src/example.js:96-361), try commenting out the patch).